### PR TITLE
Updated elusiveMice.c to work with `make` out of the box

### DIFF
--- a/src/elusiveMice.c
+++ b/src/elusiveMice.c
@@ -25,7 +25,7 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
 // POSSIBILITY OF SUCH DAMAGE.
 //===============================================================================================//
-#include "ReflectiveLoader.h"
+#include "elusiveMice.h"
 //===============================================================================================//
 // Our loader will set this to a pseudo correct HINSTANCE/HMODULE value
 HINSTANCE hAppInstance = NULL;


### PR DESCRIPTION
Updated elusiveMice.c with `#include "elusiveMice.h"` instead of `#include "ReflectiveLoader.h"`